### PR TITLE
fix: resolve ESLint errors breaking the Vercel build

### DIFF
--- a/src/components/UI/Footer/index.tsx
+++ b/src/components/UI/Footer/index.tsx
@@ -42,7 +42,7 @@ const Footer: FC = () => {
 
     // Анімація рибок
     const fish = document.querySelectorAll('.fish');
-    fish.forEach((f, index) => {
+    fish.forEach((f) => {
       gsap.to(f, {
         x: `${Math.random() * 100 - 50}%`, // Плавають випадково вліво/вправо
         y: `${Math.random() * 40 - 20}px`, // Рухаються вгору/вниз

--- a/src/components/UI/Forms/LoginForm/index.tsx
+++ b/src/components/UI/Forms/LoginForm/index.tsx
@@ -32,7 +32,7 @@ const LoginForm = () => {
           <div className="flex items-center mt-4">
             <input type="checkbox" id="remember" />
             <label htmlFor="remember" className="ml-2">
-              Запам'ятати мене
+              Запам&apos;ятати мене
             </label>
           </div>
         </div>

--- a/src/components/common/CardRecom/index.tsx
+++ b/src/components/common/CardRecom/index.tsx
@@ -7,7 +7,6 @@ import YoutubeIcon from '../IconComponents/YoutubeIcon';
 import { LakeCardProps } from '@/types/interfaces';
 
 const CardRecom: FC<LakeCardProps> = ({
-  id,
   title,
   instagramLink,
   youtubeLink,

--- a/src/components/common/IconComponents/TrophyIcon.tsx
+++ b/src/components/common/IconComponents/TrophyIcon.tsx
@@ -13,7 +13,13 @@ const TrophyIcon: FC<IconProps> = ({
   className = '',
 }) => {
   return (
-    <Image src={'/svg/trophy.svg'} width={width} height={height} alt="lake" />
+    <Image
+      className={className}
+      src={'/svg/trophy.svg'}
+      width={width}
+      height={height}
+      alt="lake"
+    />
   );
 };
 

--- a/src/data/posts.ts
+++ b/src/data/posts.ts
@@ -1,4 +1,4 @@
-export let posts = [
+export const posts = [
   {
     id: 1,
     fishingType: 'Спиннинг',


### PR DESCRIPTION
`next build` runs ESLint with prettier/prettier and next/typescript as errors, so five lint violations failed the production build:

- LoginForm: escape the apostrophe in "Запам'ятати мене" (react/no-unescaped-entities)
- CardRecom: drop unused `id` prop from destructuring
- TrophyIcon: pass the accepted `className` through to <Image>, matching FishIcon
- Footer: drop unused `index` param in the fish animation forEach
- posts: `let` -> `const` (only mutated via push, never reassigned)


Claude-Session: https://claude.ai/code/session_01YLd6kyx3uZ7AvTBPQfjDeJ